### PR TITLE
transaction function returns card disposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ try {
 }
 ```
 
-Upon calling `startTransaction()`, a transaction will be started with the card related to this connection. When successful, the given callback will be called. All interactions with the card done inside this callback will then be part of this transaction. The transaction is ended once the `Promise` returned by the callback settles. If the settled `Promise` is fulfilled, the transaction is ended with the card disposition it was fulfilled with. Otherwise the transaction is ended without any further action.
+Upon calling `startTransaction()`, a transaction will be started with the card related to this connection. When successful, the given callback will be called. All interactions with the card done inside this callback will then be part of this transaction. The transaction is ended once the `Promise` returned by the callback settles. If the settled `Promise` is fulfilled, the transaction is ended with the card disposition it was fulfilled with. If that value is `undefined` or invalid, a `"leave"` card disposition is assumed. A rejected `Promise` also causes the transaction to be ended with a `"leave"` card disposition.
 
 ## Reacting to reader availability
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If a connection is established in `"shared"` access mode, to ensure consecutive 
 
 ```js
 try {
-  const result = await connection.startTransaction(async connection => {
+  await connection.startTransaction(async connection => {
     // A transaction has successfully started.
     let firstCommand = new UInt8Array([0x00, 0xA4, 0x04, 0x00, 0x0A, 0xA0, 0x00,
         0x00, 0x00, 0x62, 0x03, 0x01, 0x0C, 0x06, 0x01]);
@@ -71,16 +71,17 @@ try {
     await connection.transmit(someOtherCommand);
     …
     await connection.transmit(finalCommand);
-    // The transaction with the card ends when the Promise settles.
+
+    // Reset the card when ending the transaction.
+    return "reset";
   });
-  // |result| has the value the Promise returned by callback above settled with.
 } catch (ex) {
   // Either the transaction failed to start, the callback
   // has thrown or the transaction failed to end.
 }
 ```
 
-Upon calling `startTransaction()`, a transaction will be started with the card related to this connection. When successful, the given callback will be called. All interactions with the card done inside this callback will then be part of this transaction. The transaction is ended once the `Promise` returned by the callback settles.
+Upon calling `startTransaction()`, a transaction will be started with the card related to this connection. When successful, the given callback will be called. All interactions with the card done inside this callback will then be part of this transaction. The transaction is ended once the `Promise` returned by the callback settles. If the settled `Promise` is fulfilled, the transaction is ended with the card disposition it was fulfilled with. Otherwise the transaction is ended without any further action.
 
 ## Reacting to reader availability
 

--- a/index.html
+++ b/index.html
@@ -357,7 +357,7 @@
           Promise&lt;undefined&gt; setAttribute([EnforceRange] unsigned long tag, BufferSource value);
         };
 
-        callback SmartCardTransactionCallback = Promise&lt;SmartCardDisposition&gt; ();
+        callback SmartCardTransactionCallback = Promise&lt;SmartCardDisposition?&gt; ();
       </pre>
       <section>
         <h3><dfn>disconnect()</dfn> method</h3>

--- a/index.html
+++ b/index.html
@@ -346,7 +346,7 @@
 
           Promise&lt;ArrayBuffer&gt; transmit(BufferSource sendBuffer);
 
-          Promise&lt;any&gt; startTransaction(TransactionStartedCallback transaction);
+          Promise&lt;undefined&gt; startTransaction(SmartCardTransactionCallback transaction);
 
           Promise&lt;SmartCardConnectionStatus&gt; status();
 
@@ -357,7 +357,7 @@
           Promise&lt;undefined&gt; setAttribute([EnforceRange] unsigned long tag, BufferSource value);
         };
 
-        callback TransactionStartedCallback = Promise&lt;any&gt; ();
+        callback SmartCardTransactionCallback = Promise&lt;SmartCardDisposition&gt; ();
       </pre>
       <section>
         <h3><dfn>disconnect()</dfn> method</h3>


### PR DESCRIPTION
This parameter is needed for the EndTransaction() PC/SC call.

It's a common practice to reset/unpower a card after exclusive use so that other PC/SC applications cannot exploit the state a card was left on.  An example is if the card was unlocked by a PIN entry during that transaction.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/8.html" title="Last updated on Jul 6, 2023, 11:00 AM UTC (25eb4a7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/8/e22cabc...25eb4a7.html" title="Last updated on Jul 6, 2023, 11:00 AM UTC (25eb4a7)">Diff</a>