### PR TITLE
Add event count information to GetStatusChange

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,7 +133,8 @@
           <pre class="idl">
             dictionary SmartCardReaderStateIn {
               required DOMString readerName;
-              required SmartCardReaderStateFlagsIn knownState;
+              required SmartCardReaderStateFlagsIn currentState;
+              unsigned long currentCount;
             };
           </pre>
 
@@ -141,9 +142,13 @@
             <dt><dfn>readerName</dfn> member</dt>
             <dd>Name of the smart card reader.</dd>
 
-            <dt><dfn>knownState</dfn> member</dt>
+            <dt><dfn>currentState</dfn> member</dt>
             <dd>The current state of that smart card reader as known by the
               application.</dd>
+
+            <dt><dfn>currentCount</dfn> member</dt>
+            <dd>The current number of card insertion and removal events in this
+              reader, as known by the application.</dd>
           </dl>
           <section data-dfn-for="SmartCardReaderStateFlagsIn">
             <h5><dfn>SmartCardReaderStateFlagsIn</dfn> dictionary</h4>
@@ -204,7 +209,8 @@
           <pre class="idl">
             dictionary SmartCardReaderStateOut {
               required DOMString readerName;
-              required SmartCardReaderStateFlagsOut state;
+              required SmartCardReaderStateFlagsOut eventState;
+              required unsigned long eventCount;
               ArrayBuffer answerToReset;
             };
           </pre>
@@ -213,8 +219,12 @@
             <dt><dfn>readerName</dfn> member</dt>
             <dd>Name of the smart card reader.</dd>
 
-            <dt><dfn>state</dfn> member</dt>
+            <dt><dfn>eventState</dfn> member</dt>
             <dd>The actual state of that smart card reader.</dd>
+
+            <dt><dfn>eventCount</dfn> member</dt>
+            <dd>The actual number of card insertion and removal events in this
+              reader.</dd>
 
             <dt><dfn>answerToReset</dfn> member</dt>
             <dd>The inserted card's [[ISO7186-3]] Answer To Reset (ATR), if


### PR DESCRIPTION
This is an undocumented API but both Windows and PCSClite implement it. PCSClite does document it, luckily. It's also not part of the PC/SC spec. It's not present on MacOS though.

Moretheless, one does need to provide this information on Windows in order for that function to work correctly, otherwise it will always return immediately as the number of expected events (zero) won't match the actual event count for that reader.

This information is "smuggled" in the upper two bytes of the dwEventState and dwCurrentState member variables of the SCARD_READERSTATE struct.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/9.html" title="Last updated on Jul 10, 2023, 4:05 PM UTC (8a75e87)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/9/c8f64a0...8a75e87.html" title="Last updated on Jul 10, 2023, 4:05 PM UTC (8a75e87)">Diff</a>