### PR TITLE
Add a sperate timeout parameter to getStatusChange()

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ try {
   let oldReaders = await context.listReaders();
 
   let allReaders = await context.getStatusChange(
-      [{readerName: "\\\\?PnP?\\Notification", currentState: {}}], 10000)
+      [{readerName: "\\\\?PnP?\\Notification", currentState: {}}],
+      {timeout: 10000})
         .then(
           (statesOut) => {
             // A new reader was added.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ try {
 
   let allReaders = await context.getStatusChange(
       [{readerName: "\\\\?PnP?\\Notification", currentState: {}}],
-      10000)
+      {timeout: 10000})
         .then(
           (statesOut) => {
             // A new reader was added.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ try {
 
   let allReaders = await context.getStatusChange(
       [{readerName: "\\\\?PnP?\\Notification", currentState: {}}],
-      AbortSignal.timeout(10000))
+      10000)
         .then(
           (statesOut) => {
             // A new reader was added.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ try {
   let oldReaders = await context.listReaders();
 
   let allReaders = await context.getStatusChange(
-      [{readerName: "\\\\?PnP?\\Notification", currentState: {}}],
-      {timeout: 10000})
+      [{readerName: "\\\\?PnP?\\Notification", currentState: {}}], 10000)
         .then(
           (statesOut) => {
             // A new reader was added.

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              SmartCardGetStatusChangeOptions options);
+              optional SmartCardGetStatusChangeOptions options);
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
           branch: "main",
           repoURL: "WICG/web-smart-card",
         },
-        xref: ["dom", "html", "permissions-policy", "webidl"],
+        xref: ["dom", "hr-time-3", "html", "permissions-policy", "webidl"],
         localBiblio: {
           // Remove this one once https://github.com/tobie/specref/pull/747 is merged:
           "PCSC5": {

--- a/index.html
+++ b/index.html
@@ -109,7 +109,9 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              optional SmartCardGetStatusChangeOptions options = {});
+              optional DOMHighResTimeStamp timeout);
+
+          Promise&lt;undefined&gt; cancel();
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,
@@ -124,8 +126,8 @@
       <section>
         <h3><dfn>getStatusChange()</dfn> method</h3>
         <p>Equivalent to the GetStatusChange method of the SCARDTRACK class from [[PCSC5]].</p>
-        <p>When the given {{AbortSignal}} is triggered, a [[PCSC5]] Cancel
-        request is made.</p>
+        <p>If a timeout is not specified, a timeout value of INFINITE (which is
+        defined system dependent) will be used.</p>
         <div class="issue">Write an algorithm for this method.</div>
         <section data-dfn-for="SmartCardReaderStateIn">
           <h4><dfn>SmartCardReaderStateIn</dfn> dictionary</h4>
@@ -283,26 +285,10 @@
             </dl>
           </section>
         </section>
-        <section data-dfn-for="SmartCardGetStatusChangeOptions">
-          <h4><dfn>SmartCardGetStatusChangeOptions</dfn> dictionary</h4>
-          <pre class="idl">
-            dictionary SmartCardGetStatusChangeOptions {
-              DOMHighResTimeStamp timeout;
-              AbortSignal signal;
-            };
-          </pre>
-
-          <dl>
-            <dt><dfn>timeout</dfn> member</dt>
-            <dd>Timeout parameter for the GetStatusChange() [[PCSC5]] method. If
-            not specified, a timeout value of INFINITE (which is defined system
-            dependent) will be used.</dd>
-
-            <dt><dfn>signal</dfn> member</dt>
-            <dd>When triggered, the platform's [[PCSC5]] Cancel() method is
-            called.</dd>
-          </dl>
-        </section>
+      </section>
+      <section>
+        <h3><dfn>cancel()</dfn> method</h3>
+        <div class="issue">Write an algorithm for this method.</div>
       </section>
       <section>
         <h3><dfn>connect()</dfn> method</h3>

--- a/index.html
+++ b/index.html
@@ -109,9 +109,7 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              optional DOMHighResTimeStamp timeout);
-
-          Promise&lt;undefined&gt; cancel();
+              optional SmartCardGetStatusChangeOptions options = {});
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,
@@ -126,8 +124,8 @@
       <section>
         <h3><dfn>getStatusChange()</dfn> method</h3>
         <p>Equivalent to the GetStatusChange method of the SCARDTRACK class from [[PCSC5]].</p>
-        <p>If a timeout is not specified, a timeout value of INFINITE (which is
-        defined system dependent) will be used.</p>
+        <p>When the given {{AbortSignal}} is triggered, a [[PCSC5]] Cancel
+        request is made.</p>
         <div class="issue">Write an algorithm for this method.</div>
         <section data-dfn-for="SmartCardReaderStateIn">
           <h4><dfn>SmartCardReaderStateIn</dfn> dictionary</h4>
@@ -285,10 +283,26 @@
             </dl>
           </section>
         </section>
-      </section>
-      <section>
-        <h3><dfn>cancel()</dfn> method</h3>
-        <div class="issue">Write an algorithm for this method.</div>
+        <section data-dfn-for="SmartCardGetStatusChangeOptions">
+          <h4><dfn>SmartCardGetStatusChangeOptions</dfn> dictionary</h4>
+          <pre class="idl">
+            dictionary SmartCardGetStatusChangeOptions {
+              DOMHighResTimeStamp timeout;
+              AbortSignal signal;
+            };
+          </pre>
+
+          <dl>
+            <dt><dfn>timeout</dfn> member</dt>
+            <dd>Timeout parameter for the GetStatusChange() [[PCSC5]] method. If
+            not specified, a timeout value of INFINITE (which is defined system
+            dependent) will be used.</dd>
+
+            <dt><dfn>signal</dfn> member</dt>
+            <dd>When triggered, the platform's [[PCSC5]] Cancel() method is
+            called.</dd>
+          </dl>
+        </section>
       </section>
       <section>
         <h3><dfn>connect()</dfn> method</h3>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,8 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              AbortSignal signal);
+              DOMHighResTimeStamp timeout,
+              optional AbortSignal signal);
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,
@@ -124,6 +125,8 @@
       <section>
         <h3><dfn>getStatusChange()</dfn> method</h3>
         <p>Equivalent to the GetStatusChange method of the SCARDTRACK class from [[PCSC5]].</p>
+        <p>When the given {{AbortSignal}} is triggered, a [[PCSC5]] Cancel
+        request is made.</p>
         <div class="issue">Write an algorithm for this method.</div>
         <section data-dfn-for="SmartCardReaderStateIn">
           <h4><dfn>SmartCardReaderStateIn</dfn> dictionary</h4>

--- a/index.html
+++ b/index.html
@@ -109,8 +109,7 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              DOMHighResTimeStamp timeout,
-              optional AbortSignal signal);
+              SmartCardGetStatusChangeOptions options);
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,
@@ -283,6 +282,26 @@
               <dd>There is an unresponsive card in the reader.</dd>
             </dl>
           </section>
+        </section>
+        <section data-dfn-for="SmartCardGetStatusChangeOptions">
+          <h4><dfn>SmartCardGetStatusChangeOptions</dfn> dictionary</h4>
+          <pre class="idl">
+            dictionary SmartCardGetStatusChangeOptions {
+              DOMHighResTimeStamp timeout;
+              AbortSignal signal;
+            };
+          </pre>
+
+          <dl>
+            <dt><dfn>timeout</dfn> member</dt>
+            <dd>Timeout parameter for the GetStatusChange() [[PCSC5]] method. If
+            not specified, a timeout value of INFINITE (which is defined system
+            dependent) will be used.</dd>
+
+            <dt><dfn>signal</dfn> member</dt>
+            <dd>When triggered, the platform's [[PCSC5]] Cancel() method is
+            called.</dd>
+          </dl>
         </section>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
           Promise&lt;sequence&lt;SmartCardReaderStateOut&gt;&gt; getStatusChange(
               sequence&lt;SmartCardReaderStateIn&gt; readerStates,
-              optional SmartCardGetStatusChangeOptions options);
+              optional SmartCardGetStatusChangeOptions options = {});
 
           Promise&lt;SmartCardConnectResult&gt; connect(
               DOMString readerName,


### PR DESCRIPTION
The timeout parameter of SCardGetStatusChange() and SCardCancel() usage are not equivalent in terms of resulting behavior.  This creates room for behavioural differences and bugs when moving PC/SC C code to be run on top of the Web API.

Here, for instance, a timeout of zero is passed:
https://github.com/OpenSC/OpenSC/blob/master/src/libopensc/reader-pcsc.c#L375 This cannot be implemented with SCardCancel.

When SCardCancel is called very close to a SCardGetStatusChange, there's no guarantee it will work and it depends on the PC/SC implementation. Even if the SCardGetStatusChange is processed before the SCardCancel, the service might still be setting up some internal state for SCardGetStatusChange and therefore that cancel might not work at that early moment.

Thus a getStatusChange() with a very short AbortSignal.timeout(ms) (eg: a couple of milliseconds) would most likely not get cancelled at all.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/10.html" title="Last updated on Jul 18, 2023, 10:07 AM UTC (6631a4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/10/fa7b710...6631a4d.html" title="Last updated on Jul 18, 2023, 10:07 AM UTC (6631a4d)">Diff</a>