### PR TITLE
Consider SCARD_E_NO_READERS_AVAILABLE in listReaders algo

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,9 +216,23 @@
                 <ol>
                   <li>Set [=this=].{{SmartCardContext/[[operationInProgress]]}} to
                     `false`.</li>
-                  <li>If |responseCode| is not `SCARD_S_SUCCESS`, [=reject=]
-                    |promise| with a {{DOMException}}
-                    {{SmartCardError/corresponding}} to |responseCode|.</li>
+                  <li>If |responseCode| is not `SCARD_S_SUCCESS`:
+                    <ol>
+                      <li>If |responseCode| is `SCARD_E_NO_READERS_AVAILABLE`,
+                      [=resolve=] |promise| with an empty `sequence` of
+                      {{DOMString}}.
+                        <aside class="note">
+                          <p>`SCARD_E_NO_READERS_AVAILABLE` is not part of
+                          [[PCSC5]] but it is still considered in this
+                          specification as existing PC/SC implementations use
+                          it.</p>
+                        </aside>
+                      </li>
+                      <li>Otherwise, [=reject=] |promise| with a
+                      {{DOMException}} {{SmartCardError/corresponding}} to
+                      |responseCode|.</li>
+                    </ol>
+                  </li>
                   <li>Otherwise, [=resolve=] |promise| with a `sequence` of
                     {{DOMString}} equivalent to |pcscReaders|.</li>
                 </ol>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/18.html" title="Last updated on Aug 3, 2023, 1:02 PM UTC (04f6b4a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/18/208e894...04f6b4a.html" title="Last updated on Aug 3, 2023, 1:02 PM UTC (04f6b4a)">Diff</a>