### PR TITLE
Expose SCARD_E_INVALID_PARAMETER as a TypeError

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
                 <li>[=Queue a global task=] on the [=relevant global object=] of
                   [=this=] using the [=smart card task source=] to [=reject=]
                   |promise| with a {{SmartCardError/corresponding}}
-                {{DOMException}}.</li>
+                  [=exception=].</li>
               </ol>
             </li>
             <li>Otherwise, perform the following steps:
@@ -221,8 +221,8 @@
                           it.</p>
                         </aside>
                       </li>
-                      <li>Otherwise, [=reject=] |promise| with a
-                      {{DOMException}} {{SmartCardError/corresponding}} to
+                      <li>Otherwise, [=reject=] |promise| with an
+                      [=exception=] {{SmartCardError/corresponding}} to
                       |responseCode|.</li>
                     </ol>
                   </li>
@@ -307,7 +307,7 @@
                       <li>If |responseCode| is `SCARD_E_CANCELLED` and
                         |abortReason| is not {{undefined}} then [=reject=]
                         |promise| with |abortReason|.</li>
-                      <li>Otherwise, [=reject=] |promise| with a {{DOMException}}
+                      <li>Otherwise, [=reject=] |promise| with an [=exception=]
                         {{SmartCardError/corresponding}} to |responseCode|.</li>
                       <li>Return.</li>
                     </ol>
@@ -701,7 +701,7 @@
                   <li>If |responseCode| is not `SCARD_S_SUCCESS`:
                     <ol>
                       <li>Destroy |comm|.</li>
-                      <li>[=Reject=] |promise| with a {{DOMException}}
+                      <li>[=Reject=] |promise| with an [=exception=]
                       {{SmartCardError/corresponding}} to |responseCode| and abort these steps.</li>
                     </ol>
                   </li>
@@ -975,7 +975,7 @@
                   <li>[=Clear the operationInProgress=] of
                     [=this=].{{SmartCardConnection/[[context]]}}.</li>
                   <li>If |responseCode| is not `SCARD_S_SUCCESS`, [=reject=]
-                    |promise| with a {{DOMException}}
+                    |promise| with an [=exception=]
                     {{SmartCardError/corresponding}} to |responseCode| and abort
                     these steps.</li>
                   <li>Destroy [=this=].{{SmartCardConnection/[[comm]]}}.</li>
@@ -1063,7 +1063,7 @@
                   <li>[=Clear the operationInProgress=] of
                     [=this=].{{SmartCardConnection/[[context]]}}.</li>
                   <li>If |responseCode| is not `SCARD_S_SUCCESS`, [=reject=]
-                    |promise| with a {{DOMException}}
+                    |promise| with an [=exception=]
                     {{SmartCardError/corresponding}} to |responseCode| and abort
                     these steps.</li>
                   <li>[=Resolve=] |promise| with an {{ArrayBuffer}} containing
@@ -1201,8 +1201,8 @@
                 <li>If |responseCode| is `SCARD_E_CANCELLED` and
                   |abortReason| is not {{undefined}} then [=reject=]
                   |promise| with |abortReason|.</li>
-                <li>Otherwise, [=reject=] |promise| with a
-                  {{DOMException}} {{SmartCardError/corresponding}} to
+                <li>Otherwise, [=reject=] |promise| with an
+                  [=exception=] {{SmartCardError/corresponding}} to
                   |responseCode|.</li>
                 <li>Return.</li>
               </ol>
@@ -1304,8 +1304,8 @@
                       <ol>
                         <li>If |responseCode| is `SCARD_S_SUCCESS`,
                           [=resolve=] |transactionPromise|.</li>
-                        <li>Otherwise, [=reject=] |transactionPromise| with a
-                          {{DOMException}} {{SmartCardError/corresponding}} to
+                        <li>Otherwise, [=reject=] |transactionPromise| with an
+                          [=exception=] {{SmartCardError/corresponding}} to
                           |responseCode|.</li>
                       </ol>
                     </li>
@@ -1373,7 +1373,7 @@
                   <li>[=Clear the operationInProgress=] of
                     [=this=].{{SmartCardConnection/[[context]]}}.</li>
                   <li>If |responseCode| is not `SCARD_S_SUCCESS`, [=reject=]
-                    |promise| with a {{DOMException}}
+                    |promise| with an [=exception=]
                     {{SmartCardError/corresponding}} to |responseCode| and abort
                     these steps.</li>
                   <li>Let |state:SmartCardConnectionState| be a
@@ -1519,7 +1519,7 @@
       <p>The <dfn>responseCode</dfn> attribute is the error or warning response
       code returned by the related [[PCSC5]] method.</p>
       <p>Given a [[PCSC5]] `RESPONSECODE` different from `SCARD_S_SUCCESS`, a
-      <dfn data-dfn-for="SmartCardError">corresponding</dfn> {{DOMException}} is
+      <dfn data-dfn-for="SmartCardError">corresponding</dfn> [=exception=] is
       created with the following steps:</p>
       <aside class="note" title="Unspecified response codes">
         <p>The following `RESPONSECODE`s are not part of [[PCSC5]] but are still
@@ -1577,6 +1577,8 @@
         <li>If |pcscCode| is `SCARD_E_UNSUPPORTED_FEATURE`, return a [=new=]
           {{SmartCardResponseCode/"unsupported-feature"}}
           {{SmartCardError}}.</li>
+        <li>If |pcscCode| is `SCARD_E_INVALID_PARAMETER`, return a [=new=]
+          {{TypeError}}.</li>
         <li>If |pcscCode| is `SCARD_E_INVALID_HANDLE`, return a [=new=]
           "{{InvalidStateError}}" {{DOMException}}.</li>
         <li>If |pcscCode| is `SCARD_E_SERVICE_STOPPED`, return a [=new=]


### PR DESCRIPTION
This is not only triggered by bad PC/SC API usage (eg, passing a null context), which would be a browser implementation bug. It can also be returned by the reader driver or card on input that, from a pure PC/SC API perspective, is perfectly valid.

One example is when the user tries to transmit an APDU that is too big for the smart card at hand (eg, card has not enough memory to hold it).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/25.html" title="Last updated on Aug 25, 2023, 1:09 PM UTC (6c0be4d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/25/f09e3da...6c0be4d.html" title="Last updated on Aug 25, 2023, 1:09 PM UTC (6c0be4d)">Diff</a>