### PR TITLE
Fix algo for filling out a SCARD_READERSTATE from a SmartCardReaderStateIn

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,7 +363,9 @@
                 <li>Set |pcscState|.`CurrentState` to the `DWORD`
                   [=SmartCardReaderStateFlagsIn/corresponding=]
                 to |stateIn|["{{SmartCardReaderStateIn/currentState}}"].</li>
-                <li>[=SmartCardContext/Set the high word=] of |pcscState|.`CurrentState` to
+                <li>If |stateIn|["{{SmartCardReaderStateIn/currentCount}}"]
+                  [=map/exists=], [=SmartCardContext/set the high word=] of
+                  |pcscState|.`CurrentState` to
                   |stateIn|["{{SmartCardReaderStateIn/currentCount}}"].</li>
                 <li>Set |pcscState|.`EventState` to zero.</li>
                 <li>[=list/Append=] |pcscState| to |pcscReaderStates|.</li>


### PR DESCRIPTION
Regarding the presence of currentCount in the dictionary.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/pull/29.html" title="Last updated on Sep 18, 2023, 9:52 AM UTC (d67301c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/29/55b09cb...d67301c.html" title="Last updated on Sep 18, 2023, 9:52 AM UTC (d67301c)">Diff</a>