### PR TITLE
Switching builder to ubuntu-latest to fix deploy

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy Spec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
The example in https://github.com/w3c/spec-prod suggests to use ubuntu-latest - and ubuntu-20.04 is out of support, causing deploys to fail.