### PR TITLE
Fix transaction deadlocks by tracking active transactions per reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,13 @@
           <td>Whether there is an ongoing PC/SC operation in this context.</td>
         </tr>
         <tr>
+          <td><dfn>[[\activeReaderTransactions]]</dfn></td>
+          <td>An empty <a data-cite="infra#map">map</a></td>
+          <td>A <a data-cite="infra#map">map</a> of reader names to the {{SmartCardConnection}} that
+            currently holds an active transaction on that reader in this
+            context, if any.</td>
+        </tr>
+        <tr>
           <td><dfn>[[\connections]]</dfn></td>
           <td>An empty [=ordered set=]</td>
           <td>The existing {{SmartCardConnection}}s created by this context.</td>
@@ -704,6 +711,9 @@
           <li>If [=this=].{{SmartCardContext/[[operationInProgress]]}} is
             `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
             {{DOMException}} and return |promise|.</li>
+          <li>If [=this=].{{SmartCardContext/[[activeReaderTransactions]]}}[|readerName|]
+            [=map/exists=], [=reject=] |promise| with a "{{InvalidStateError}}"
+            {{DOMException}} and return |promise|.</li>
           <li>Set [=this=].{{SmartCardContext/[[operationInProgress]]}} to
             `true`.</li>
           <li>Run the following steps [=in parallel=]:
@@ -744,6 +754,8 @@
                   <li>[=set/Append=] |connection| to
                     [=this=].{{SmartCardContext/[[connections]]}}.</li>
                   <li>Set |connection|.{{SmartCardConnection/[[comm]]}} to |comm|.
+                  <li>Set |connection|.{{SmartCardConnection/[[readerName]]}} to
+                    |readerName|.
                   <li>Set |connection|.{{SmartCardConnection/[[context]]}} to
                     [=this=].
                   <li>Set |connection|.{{SmartCardConnection/[[activeProtocol]]}} to
@@ -959,6 +971,11 @@
           <td>The platform's [[PCSC5]] `SCARDCOMM` to be used.</td>
         </tr>
         <tr>
+          <td><dfn>[[\readerName]]</dfn></td>
+          <td>`null`</td>
+          <td>The name of the reader this connection is associated with.</td>
+        </tr>
+        <tr>
           <td><dfn>[[\context]]</dfn></td>
           <td>`null`</td>
           <td>The {{SmartCardContext}} that created this instance.</td>
@@ -998,6 +1015,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1067,6 +1089,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1140,6 +1167,10 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=], [=reject=] |promise| with a "{{InvalidStateError}}"
+            {{DOMException}} and return |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1255,6 +1286,9 @@
               |promise|.</li>
             <li>Set |connection|.{{SmartCardConnection/[[transactionState]]}}
               to |transactionState|.</li>
+            <li>Set
+              |connection|.{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[|connection|.{{SmartCardConnection/[[readerName]]}}]
+              to |connection|.</li>
             <li>Let |callbackPromise:Promise| be the result of [=invoking=]
               |transaction|.</li>
             <li>[=promise/React=] to |callbackPromise|:
@@ -1340,6 +1374,8 @@
                   <ol>
                     <li>[=Clear the operationInProgress=] of
                       |connection|.{{SmartCardConnection/[[context]]}}.</li>
+                    <li>[=map/Remove=] |connection|.{{SmartCardConnection/[[readerName]]}}
+                      from |connection|.{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}.</li>
                     <li>Let |exception| be
                       |connection|.{{SmartCardConnection/[[transactionState]]}}'s
                       [=transaction state/pendingException=].</li>
@@ -1391,6 +1427,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1539,6 +1580,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1590,6 +1636,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>
@@ -1642,6 +1693,11 @@
             [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[operationInProgress]]}}
             is `true`, [=reject=] |promise| with a "{{InvalidStateError}}"
           {{DOMException}} and return |promise|.</li>
+          <li>If
+            [=this=].{{SmartCardConnection/[[context]]}}.{{SmartCardContext/[[activeReaderTransactions]]}}[[[=this=].{{SmartCardConnection/[[readerName]]}}]]
+            [=map/exists=] and is not equal to [=this=], [=reject=] |promise|
+            with a "{{InvalidStateError}}" {{DOMException}} and return
+            |promise|.</li>
           <li>If [=this=].{{SmartCardConnection/[[comm]]}} is `null`, [=reject=]
             |promise| with a "{{InvalidStateError}}" {{DOMException}} and return
             |promise|.</li>


### PR DESCRIPTION
**The Problem**
When a transaction is started, native PC/SC blocks subsequent operations on that reader until the transaction completes. Previously, the specification did not track the owner of this exclusive lock. Because `context.[[operationInProgress]]` is temporarily cleared while yielding to the JavaScript transaction callback, a second connection to the same reader could bypass the API's guardrails. This would permanently hang the native PC/SC thread, causing a fatal assertion failure (`Assert: connection.[[context]].[[operationInProgress]] is false`) and an unrecoverable deadlock.

**The Solution**
This change introduces connection-level ownership tracking of active transactions on a per-reader basis. Conflicting operations from other connections are now synchronously rejected at the JavaScript boundary. This aligns the API with underlying PC/SC isolation semantics and safely permits concurrent operations across *different* readers within the same context.

**Specific Changes**
* Added the `[[activeReaderTransactions]]` internal slot to `SmartCardContext` (a map of reader names to connections) to track which connection currently holds an exclusive transaction lock.
* Added the `[[readerName]]` internal slot to `SmartCardConnection`.
* Updated `connect()` to initialize the connection's `[[readerName]]` and verify that no active transactions are currently blocking the requested reader.
* Updated the guardrails in `transmit()`, `control()`, `getAttribute()`, `setAttribute()`, `startTransaction()`, and `disconnect()`. These methods now immediately reject with an `InvalidStateError` if a different connection holds an active transaction on the target reader.

**Deadlock Example**
This implementation successfully prevents the following failure state:
1. Connection A and Connection B are initiated to Reader X.
2. Connection A starts a transaction. After the native `BeginTransaction` succeeds, the API sets `context.[[operationInProgress]] = false` to safely yield to the JS callback.
3. Connection B calls `transmit()`. Because the operation flag is false, it proceeds, sets `context.[[operationInProgress]] = true`, and invokes the native PC/SC call.
4. PC/SC natively blocks Connection B indefinitely, waiting for Connection A's transaction to end.
5. Connection A's callback resolves. The API attempts to end the transaction but fails the `Assert: connection.[[context]].[[operationInProgress]] is false` invariant, leaving the system deadlocked.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zgroza/web-smart-card/pull/50.html" title="Last updated on Apr 23, 2026, 6:13 PM UTC (3271aca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/web-smart-card/50/80ce56f...zgroza:3271aca.html" title="Last updated on Apr 23, 2026, 6:13 PM UTC (3271aca)">Diff</a>